### PR TITLE
Update Installation part of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repo explores the use of an LLM code generation pipeline to write simulatio
 
 ## ⚙️ Installation
 0. ``pip install -r requirements.txt``
-1. ``python setup.py develop``
+1. ``python -m pip install --editable .``
 2. ``export GENSIM_ROOT=$(pwd)``
 3. ``export OPENAI_KEY=YOUR KEY``. We use OpenAI's GPT-4 as the language model. You need to have an OpenAI API key to run task generation with GenSim. You can get one from [here](https://platform.openai.com/account/api-keys).
 


### PR DESCRIPTION
`python setup.py`and the use of `setup.py` as a command line tool are deprecated in high versions of pip. The installation part in README.md confuses users when installing the project, thus it may be better to change it according to [this article](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/).